### PR TITLE
Make podium scale dependent on number of players, add a `-n` switch to specify player number from command line

### DIFF
--- a/jeoparpy/config.py
+++ b/jeoparpy/config.py
@@ -78,3 +78,6 @@ DEBUG = False
 
 #Flash drive
 DRIVE = False
+
+# The number of players
+PLAYER_NUM = 3

--- a/jeoparpy/main.py
+++ b/jeoparpy/main.py
@@ -23,7 +23,7 @@ from pygame.locals import *
 import os
 import sys
 
-from .config import FPS_LIMIT, FULLSCREEN, SUBTRACT_ON_INCORRECT, SCREEN_SIZE
+from .config import FPS_LIMIT, FULLSCREEN, PLAYER_NUM, SUBTRACT_ON_INCORRECT, SCREEN_SIZE
 from .constants import ANIMATIONEND, ANSWER_TIMEOUT, AUDIOEND, SKIP_INTRO_FLAG
 from .game import GameData, JeopGameState
 from .ui import Controller, do_congrats, do_credits, do_intro, do_scroll
@@ -161,7 +161,9 @@ def handle_event_key(event, gameState, gameData):
     elif gs.state == gs.WAIT_TRIGGER_AUDIO and event.key == K_m:
         gs.set(gs.PLAY_CLUE_AUDIO, coords=gs.kwargs['coords'])
 
-    elif gs.state == gs.WAIT_BUZZ_IN and event.key in (K_1, K_2, K_3):
+    # Check if the state is WAIT_BUZZ_IN, and the key is a number coresponding to a player
+    elif gs.state == gs.WAIT_BUZZ_IN and event.key in range(K_1, K_1 + PLAYER_NUM):
+        # Get player id from key
         p = event.key - K_1
         if not gameData.players[p].hasAnswered:
             gs.set(gs.BUZZ_IN, playerI=p, amount=gs.kwargs['amount'])

--- a/jeoparpy/ui/maingame/podiapanel.py
+++ b/jeoparpy/ui/maingame/podiapanel.py
@@ -20,6 +20,7 @@ from .jeopgamesfc import JeopGameSurface
 from .podium import Podium
 from ..resmaps import FONTS, IMAGES
 
+from ...config import PLAYER_NUM
 
 class PodiaPanel(JeopGameSurface):
     """
@@ -72,11 +73,17 @@ class PodiaPanel(JeopGameSurface):
 
     def _init_background(self):
         img = pygame.image.load(IMAGES['rPanelBG']).convert()
+
         sizeScalar = float(self.size[1]) / img.get_size()[1]
+
+        # Change the scalar depending on the number of players
+        # NOTE: I don't really know why this involves a 3
+        sizeScalar = sizeScalar * (3 / PLAYER_NUM)
+
         img = pygame.transform.scale(img, self.size)
         self.blit(img, (0, 0))
 
-        return sizeScalar * .75
+        return sizeScalar
 
     def _init_podia(self, gameData, scalar):
         podia = pygame.sprite.OrderedUpdates()
@@ -85,15 +92,15 @@ class PodiaPanel(JeopGameSurface):
         fonts = (('team1', 42), ('team2', 33), ('team3', 40), ('team1', 42), ('team2', 33))
         fonts = tuple((FONTS[n], s) for n,s in fonts)
 
-        for i in range(5):
+        for i in range(PLAYER_NUM):
             p = Podium(i, img, scalar, gameData.players[i].name,
                        fonts[i], nameBounds, podia)
 
         return self._position_podia(podia)
 
     def _position_podia(self, podia):
-        ph = podia.sprites()[0].rect.h - 10
-        padding = (self.size[1] - 5*ph) / 4
+        ph = podia.sprites()[0].rect.h
+        padding = (self.size[1] - PLAYER_NUM*ph) / 4
         y = padding
 
         for p in podia:

--- a/start.py
+++ b/start.py
@@ -44,7 +44,7 @@ optionsMap = {
     '--skip-intro' : SKIP_INTRO_FLAG,
     '-w'           : WINDOWED_FLAG,
     '--windowed'   : WINDOWED_FLAG,
-    '--drive'       : DRIVE_FLAG,
+    '--drive'      : DRIVE_FLAG,
 }
 
 if __name__ == '__main__':

--- a/start.py
+++ b/start.py
@@ -48,7 +48,36 @@ optionsMap = {
 }
 
 if __name__ == '__main__':
-    flags = set(optionsMap[o] for o in argv if o in optionsMap)
+    rawFlags = []
+
+    # Loop over args, add all args to rawFlags unless it is -n or the arg after it
+    i = 0
+    while i < len(argv):
+        if argv[i] == '-n':
+            i += 1
+            try:
+                num = int(argv[i])
+                if num < 3 or num > 5:
+                    print("Please specify a number of players from 3 to 5")
+                    print("Or, omit it and the number of players will default to 3")
+                    exit(1)
+            except ValueError:
+                print(f'{argv[i]} is not a valid number')
+                exit(1)
+
+            config.PLAYER_NUM = num
+
+        elif argv[i] in ('-h', '--help'):
+            print('Sorry, the help flag has not been implemented yet')
+            exit(0)
+
+        elif argv[i] in optionsMap:
+            rawFlags.append(optionsMap[argv[i]])
+
+        i += 1
+
+    # Get rid of duplicates
+    flags = set(rawFlags)
     
     # Override config options if args provided
     if FULLSCREEN_FLAG in flags:


### PR DESCRIPTION
Add a new constant `PLAYER_NUM` in `jeoparpy.config` which is `3` by default. The `-n <number>` flag changes this

The scale of podiums is dependent on the number of players

Close #8
Close #11
Close #12

Also add framework for creating a `-h` or `--help` switch in the future